### PR TITLE
Make users events specific

### DIFF
--- a/users/src/main/java/nl/tudelft/wdm/group1/users/events/Consumer.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/events/Consumer.java
@@ -1,5 +1,6 @@
 package nl.tudelft.wdm.group1.users.events;
 
+import nl.tudelft.wdm.group1.users.ResourceNotFoundException;
 import nl.tudelft.wdm.group1.users.User;
 import nl.tudelft.wdm.group1.users.UserRepository;
 import org.slf4j.Logger;
@@ -22,5 +23,12 @@ public class Consumer {
         logger.info(String.format("#### -> Consumed message -> %s", user));
 
         userRepository.addOrReplace(user);
+    }
+
+    @KafkaListener(topics = "userDeleted")
+    public void consumeUserDeleted(User user) throws ResourceNotFoundException {
+        logger.info(String.format("#### -> Consumed message -> %s", user));
+
+        userRepository.remove(user.getId());
     }
 }

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/events/Consumer.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/events/Consumer.java
@@ -17,7 +17,7 @@ public class Consumer {
         this.userRepository = userRepository;
     }
 
-    @KafkaListener(topics = "${spring.kafka.topic}")
+    @KafkaListener(topics = {"userCreated", "creditAdded", "creditSubtracted"})
     public void consume(User user) {
         logger.info(String.format("#### -> Consumed message -> %s", user));
 

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/events/Producer.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/events/Producer.java
@@ -19,6 +19,11 @@ public class Producer {
         this.kafkaTemplate.send("userCreated", user);
     }
 
+    public void emitUserDeleted(User user) {
+        logger.info(String.format("#### -> Producing message -> %s", user));
+        this.kafkaTemplate.send("userDeleted", user);
+    }
+
     public void emitCreditSubtracted(User user) {
         logger.info(String.format("#### -> Producing message -> %s", user));
         this.kafkaTemplate.send("creditSubtracted", user);

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/events/Producer.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/events/Producer.java
@@ -4,7 +4,6 @@ import nl.tudelft.wdm.group1.users.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -12,14 +11,21 @@ import org.springframework.stereotype.Service;
 public class Producer {
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
 
-    @Value("${spring.kafka.topic}")
-    private String topic;
-
     @Autowired
     private KafkaTemplate<String, User> kafkaTemplate;
 
-    public void send(User user) {
+    public void emitUserCreated(User user) {
         logger.info(String.format("#### -> Producing message -> %s", user));
-        this.kafkaTemplate.send(topic, user);
+        this.kafkaTemplate.send("userCreated", user);
+    }
+
+    public void emitCreditSubtracted(User user) {
+        logger.info(String.format("#### -> Producing message -> %s", user));
+        this.kafkaTemplate.send("creditSubtracted", user);
+    }
+
+    public void emitCreditAdded(User user) {
+        logger.info(String.format("#### -> Producing message -> %s", user));
+        this.kafkaTemplate.send("creditAdded", user);
     }
 }

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/web/CreditController.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/web/CreditController.java
@@ -38,7 +38,7 @@ public class CreditController {
     ) throws ResourceNotFoundException, InsufficientCreditException {
         User user = userRepository.find(id);
         user.subtractCredit(amount);
-        producer.send(user);
+        producer.emitCreditSubtracted(user);
         return user;
     }
 
@@ -49,7 +49,7 @@ public class CreditController {
     ) throws ResourceNotFoundException {
         User user = userRepository.find(id);
         user.addCredit(amount);
-        producer.send(user);
+        producer.emitCreditAdded(user);
         return user;
     }
 }

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/web/UserController.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/web/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
     ) {
         User user = new User(firstName, lastName, street, zip, city);
 
-        producer.send(user);
+        producer.emitUserCreated(user);
 
         return user;
     }

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/web/UserController.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/web/UserController.java
@@ -50,6 +50,6 @@ public class UserController {
 
     @DeleteMapping("/{id}")
     public void removeUser(@PathVariable(value = "id") UUID id) throws ResourceNotFoundException {
-        userRepository.remove(id);
+        producer.emitUserDeleted(userRepository.find(id));
     }
 }

--- a/users/src/main/resources/application.yml
+++ b/users/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 spring:
   kafka:
-    topic: users3
     consumer:
       bootstrap-servers: localhost:9092
       group-id: group_id2

--- a/users/src/test/java/nl/tudelft/wdm/group1/users/UsersApplicationTests.java
+++ b/users/src/test/java/nl/tudelft/wdm/group1/users/UsersApplicationTests.java
@@ -84,6 +84,8 @@ public class UsersApplicationTests {
         this.mockMvc.perform(delete("/users/" + defaultUser.getId()))
                 .andExpect(status().isOk());
 
+        Thread.sleep(2000); // TODO: Remove this ugly hack
+
         assertThatThrownBy(() -> userRepository.find(defaultUser.getId()))
                 .isInstanceOf(ResourceNotFoundException.class);
     }


### PR DESCRIPTION
This PR makes all users events specific events instead of one general "users" event.

This can also serve as an example for how to deal with multiple topics in the other microservices.

User deletion is now only performed after submitting/handling an event.

Credit add/subtract is still somewhat 'odd' since we perform the action before sending the event. I expect to improve this in a future PR.