### PR TITLE
Disallow negative credit additions/subtractions

### DIFF
--- a/users/src/main/java/nl/tudelft/wdm/group1/users/CreditChangeInvalidException.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/CreditChangeInvalidException.java
@@ -1,0 +1,11 @@
+package nl.tudelft.wdm.group1.users;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.UNPROCESSABLE_ENTITY)
+public class CreditChangeInvalidException extends Exception {
+    public CreditChangeInvalidException(String message) {
+        super(message);
+    }
+}

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/User.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/User.java
@@ -51,11 +51,17 @@ public class User {
         return credit;
     }
 
-    public void addCredit(int amount) {
+    public void addCredit(int amount) throws CreditChangeInvalidException {
+        if (amount < 0) {
+            throw new CreditChangeInvalidException("A negative credit amount cannot be added.");
+        }
         credit += amount;
     }
 
-    public void subtractCredit(int amount) throws InsufficientCreditException {
+    public void subtractCredit(int amount) throws InsufficientCreditException, CreditChangeInvalidException {
+        if (amount < 0) {
+            throw new CreditChangeInvalidException("A negative credit amount cannot be subtracted.");
+        }
         if (amount > credit) {
             throw new InsufficientCreditException("Insufficient balance.");
         }

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/web/CreditController.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/web/CreditController.java
@@ -1,5 +1,6 @@
 package nl.tudelft.wdm.group1.users.web;
 
+import nl.tudelft.wdm.group1.users.CreditChangeInvalidException;
 import nl.tudelft.wdm.group1.users.InsufficientCreditException;
 import nl.tudelft.wdm.group1.users.ResourceNotFoundException;
 import nl.tudelft.wdm.group1.users.User;
@@ -35,7 +36,7 @@ public class CreditController {
     public User subtractCredit(
             @PathVariable(value = "id") UUID id,
             @PathVariable(value = "amount") int amount
-    ) throws ResourceNotFoundException, InsufficientCreditException {
+    ) throws ResourceNotFoundException, InsufficientCreditException, CreditChangeInvalidException {
         User user = userRepository.find(id);
         user.subtractCredit(amount);
         producer.send(user);
@@ -46,7 +47,7 @@ public class CreditController {
     public User addCredit(
             @PathVariable(value = "id") UUID id,
             @PathVariable(value = "amount") int amount
-    ) throws ResourceNotFoundException {
+    ) throws ResourceNotFoundException, CreditChangeInvalidException {
         User user = userRepository.find(id);
         user.addCredit(amount);
         producer.send(user);

--- a/users/src/test/java/nl/tudelft/wdm/group1/users/UsersApplicationTests.java
+++ b/users/src/test/java/nl/tudelft/wdm/group1/users/UsersApplicationTests.java
@@ -37,7 +37,7 @@ public class UsersApplicationTests {
     private User defaultUser;
 
     @Before
-    public void setUp() {
+    public void setUp() throws CreditChangeInvalidException {
         defaultUser = new User("John", "Doe", "Mekelweg 4", "2628 CD", "Delft");
         defaultUser.addCredit(2249);
         userRepository.add(defaultUser);
@@ -104,6 +104,14 @@ public class UsersApplicationTests {
     }
 
     @Test
+    public void addNegativeCreditAmount() throws Exception {
+        this.mockMvc.perform(post("/users/" + defaultUser.getId() + "/credit/add/-1500"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(defaultUser.getCredit()).isEqualTo(2249);
+    }
+
+    @Test
     public void subtractCreditWhenAvailable() throws Exception {
         this.mockMvc.perform(post("/users/" + defaultUser.getId() + "/credit/subtract/1500"))
                 .andExpect(status().isOk());
@@ -114,6 +122,14 @@ public class UsersApplicationTests {
     @Test
     public void subtractCreditWhenNotAvailable() throws Exception {
         this.mockMvc.perform(post("/users/" + defaultUser.getId() + "/credit/subtract/3000"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(defaultUser.getCredit()).isEqualTo(2249);
+    }
+
+    @Test
+    public void subtractNegativeCreditAmount() throws Exception {
+        this.mockMvc.perform(post("/users/" + defaultUser.getId() + "/credit/subtract/-1500"))
                 .andExpect(status().isUnprocessableEntity());
 
         assertThat(defaultUser.getCredit()).isEqualTo(2249);


### PR DESCRIPTION
This PR adds a check for negative credit additions/subtractions. An exception is thrown whenever such a situation occurs, resulting in a `422: Unprocessable Entity` for the user.