### PR TITLE
Add end to end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
+.env
 
 ### STS ###
 .apt_generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
 language: java
 
+services:
+  - docker
+
+install: skip
+script: skip
+
+jobs:
+  include:
+    - stage: test
+      name: "Test orders service"
+      script: ./ci/build.sh orders
+    - script: ./ci/build.sh payments
+      name: "Test payments service"
+    - script: ./ci/build.sh stock
+      name: "Test stock service"
+    - script: ./ci/build.sh users
+      name: "Test users service"
+    - stage: end-to-end
+      name: "Run end-to-end tests"
+      script: ./ci/test.sh
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,6 @@ buildscript {
 
 subprojects {
     apply plugin: "java"
-    apply plugin: "org.springframework.boot"
-    apply plugin: 'io.spring.dependency-management'
 
     group = 'nl.tudelft.wdm.group1'
     version = '0.0.1-SNAPSHOT'
@@ -21,6 +19,12 @@ subprojects {
     repositories {
         mavenCentral()
     }
+}
+
+// end-to-end does not need spring
+configure(subprojects - project(":end-to-end")) {
+    apply plugin: "org.springframework.boot"
+    apply plugin: 'io.spring.dependency-management'
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ev
+
+SUB_PROJECT=$1
+IMAGE_NAME=wdmk/${SUB_PROJECT}:${TRAVIS_BRANCH}_${TRAVIS_BUILD_NUMBER}
+IMAGE_NAME_SHORT=wdmk/${SUB_PROJECT}:${TRAVIS_BRANCH}
+
+# Build and test this sub project
+./gradlew :${SUB_PROJECT}:assemble :${SUB_PROJECT}:check
+
+# Create a docker image for this sub project
+docker build -t ${IMAGE_NAME} -t ${IMAGE_NAME_SHORT} ${SUB_PROJECT}
+
+# Login into docker hub
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+# Push the image to docker hub
+docker push ${IMAGE_NAME}
+
+# For branch builds push the image with the branch name as tag
+if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+  docker push ${IMAGE_NAME_SHORT}
+
+  # For master also push to the latest tag
+  if [[ "$TRAVIS_BRANCH" = "master" ]]; then
+    docker tag ${IMAGE_NAME} ${IMAGE_NAME_LATEST}
+    docker push ${IMAGE_NAME} ${IMAGE_NAME_LATEST}
+  fi
+fi
+
+# If a branch is tagged, also push to that tag in docker hub
+if [[ -n "$TRAVIS_TAG" ]]; then
+  IMAGE_NAME_TAG=wdmk/${SUB_PROJECT}:"$TRAVIS_TAG"
+  docker tag ${IMAGE_NAME} ${IMAGE_NAME_TAG}
+  docker push ${IMAGE_NAME} ${IMAGE_NAME_TAG}
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Docker compose looks in .env for environment variables
+echo IMAGE_VERSION=${TRAVIS_BRANCH}_${TRAVIS_BUILD_NUMBER} > .env
+
+# Pull the images created in build.sh from docker hub
+docker-compose pull
+
+# Start the environment in the background
+docker-compose up -d
+
+# Wait until the gateway is ready, so no 504 or 502 status is returned
+attempt_num=1
+
+until curl -Is http://localhost:8080/users | head -1 | grep -v 50
+do
+ if (( attempt_num == 10 ))
+ then
+     return 1
+ else
+     echo Retrying to connect
+     sleep $(( attempt_num++ ))
+ fi
+done
+
+# Run the end to end tests with gradle
+./gradlew end-to-end-test
+
+# Remove the docker containers
+docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,24 +23,28 @@ services:
     ports:
       - "8080:80"
   orders:
+    image: wdmk/orders:${IMAGE_VERSION:-latest}
     build: orders
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   payments:
+    image: wdmk/payments:${IMAGE_VERSION:-latest}
     build: payments
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   stock:
+    image: wdmk/stock:${IMAGE_VERSION:-latest}
     build: stock
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   users:
+    image: wdmk/users:${IMAGE_VERSION:-latest}
     build: users
     links:
       - kafka

--- a/end-to-end/build.gradle
+++ b/end-to-end/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+    compile group: 'junit', name: 'junit', version: '4.12'
+    compile group: 'io.rest-assured', name: 'rest-assured', version: '4.0.0'
+}
+
+// By default tests and build are disable so they are not ran when the project builds.
+assemble.enabled = false;
+test.enabled = false;
+
+task 'end-to-end-test' {
+    test.enabled = true;
+    dependsOn 'test'
+}

--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endToEnd/EndToEndTest.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endToEnd/EndToEndTest.java
@@ -1,0 +1,24 @@
+package nl.tudelft.wdm.group1.endToEnd;
+
+import static org.hamcrest.Matchers.*;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+
+public class EndToEndTest {
+    @Test
+    public void createAndDeleteUser() {
+        RestAssured
+                .given()
+                .param("firstName", "Jane")
+                .param("lastName", "Da")
+                .param("street", "Main Street")
+                .param("zip", "90101")
+                .param("city", "Rome")
+                .when()
+                .post("http://localhost:8080/users")
+                .then()
+                .body("firstName", equalTo("Jane"))
+                .body("lastName", equalTo("Da"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ pluginManagement {
 
 rootProject.name = 'wdm-kafka-microservices'
 
-include 'users', 'orders', 'stock', 'payments'
+include 'users', 'orders', 'stock', 'payments', 'end-to-end'


### PR DESCRIPTION
Creates five jobs in two stages, the first four run in parallel and build the seperate microservices. The last job pulls all microservices, zookeeper, kafka and nginx and runs end-to-end tests on that setup.

Docker images are pushed to the [wdmk](https://cloud.docker.com/u/wdmk/repository/list)(Web-scale Data Management Kafka) namespace on Docker Hub. Images with tags are tagged and the master branch produces the latest images. This might become aws or we push to both.

This means that you can do `docker-compose pull` (after this is merged) and `docker-compose up` to get up and running. Moving to Kube should be straightforward at this point.

I altered the gradle setup a bit, because `spring boot` and `rest assured` both depend on different versions of gson. This gave problems. I am not sure if this is the best way to do this or if there is a way to have a seperate project inside a project in another way. It is important that the end to end tests are not called by accident, because they will likely fail.