### PR TITLE
Add functionality for orders

### DIFF
--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/Order.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/Order.java
@@ -1,5 +1,6 @@
 package nl.tudelft.wdm.group1.orders;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,10 +12,10 @@ public class Order {
     public Order() {
     }
 
-    public Order(UUID userId, Set<UUID> itemIds) {
+    public Order(UUID userId) {
         id = UUID.randomUUID();
         this.userId = userId;
-        this.itemIds = itemIds;
+        this.itemIds = new HashSet<>();
     }
 
     public UUID getId() {

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/Order.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/Order.java
@@ -1,22 +1,48 @@
 package nl.tudelft.wdm.group1.orders;
 
+import java.util.Set;
 import java.util.UUID;
 
 public class Order {
     private UUID id;
+    private UUID userId;
+    private Set<UUID> itemIds;
 
     public Order() {
-        id = UUID.randomUUID(); // TODO: Remove this line as soon as the non-default constructor is created
+    }
+
+    public Order(UUID userId, Set<UUID> itemIds) {
+        id = UUID.randomUUID();
+        this.userId = userId;
+        this.itemIds = itemIds;
     }
 
     public UUID getId() {
         return id;
     }
 
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public Set<UUID> getItemIds() {
+        return itemIds;
+    }
+
+    public void addItem(UUID itemId) {
+        itemIds.add(itemId);
+    }
+
+    public void deleteItem(UUID itemId) {
+        itemIds.remove(itemId);
+    }
+
     @Override
     public String toString() {
         return "Order{" +
                 "id=" + id +
+                ", userId=" + userId +
+                ", itemIds=" + itemIds +
                 '}';
     }
 }

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/events/Consumer.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/events/Consumer.java
@@ -2,6 +2,7 @@ package nl.tudelft.wdm.group1.orders.events;
 
 import nl.tudelft.wdm.group1.orders.Order;
 import nl.tudelft.wdm.group1.orders.OrderRepository;
+import nl.tudelft.wdm.group1.orders.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -17,10 +18,17 @@ public class Consumer {
         this.orderRepository = orderRepository;
     }
 
-    @KafkaListener(topics = "${spring.kafka.topic}")
+    @KafkaListener(topics = {"orderCreated", "orderItemAdded", "orderItemDeleted", "orderCheckedOut"})
     public void consume(Order order) {
         logger.info(String.format("#### -> Consumed message -> %s", order));
 
         orderRepository.addOrReplace(order);
+    }
+
+    @KafkaListener(topics = "orderDeleted")
+    public void consumeOrderDeleted(Order order) throws ResourceNotFoundException {
+        logger.info(String.format("#### -> Consumed message -> %s", order));
+
+        orderRepository.remove(order.getId());
     }
 }

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/events/Producer.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/events/Producer.java
@@ -4,7 +4,6 @@ import nl.tudelft.wdm.group1.orders.Order;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -12,14 +11,31 @@ import org.springframework.stereotype.Service;
 public class Producer {
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
 
-    @Value("${spring.kafka.topic}")
-    private String topic;
-
     @Autowired
     private KafkaTemplate<String, Order> kafkaTemplate;
 
-    public void send(Order order) {
+    public void emitOrderCreated(Order order) {
         logger.info(String.format("#### -> Producing message -> %s", order));
-        this.kafkaTemplate.send(topic, order);
+        this.kafkaTemplate.send("orderCreated", order);
+    }
+
+    public void emitOrderDeleted(Order order) {
+        logger.info(String.format("#### -> Producing message -> %s", order));
+        this.kafkaTemplate.send("orderDeleted", order);
+    }
+
+    public void emitOrderItemAdded(Order order) {
+        logger.info(String.format("#### -> Producing message -> %s", order));
+        this.kafkaTemplate.send("orderItemAdded", order);
+    }
+
+    public void emitOrderItemDeleted(Order order) {
+        logger.info(String.format("#### -> Producing message -> %s", order));
+        this.kafkaTemplate.send("orderItemDeleted", order);
+    }
+
+    public void emitOrderCheckedOut(Order order) {
+        logger.info(String.format("#### -> Producing message -> %s", order));
+        this.kafkaTemplate.send("orderCheckedOut", order);
     }
 }

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/OrderController.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/OrderController.java
@@ -1,9 +1,8 @@
 package nl.tudelft.wdm.group1.orders.web;
 
-import nl.tudelft.wdm.group1.orders.OrderRepository;
-import nl.tudelft.wdm.group1.orders.ResourceNotFoundException;
 import nl.tudelft.wdm.group1.orders.Order;
 import nl.tudelft.wdm.group1.orders.OrderRepository;
+import nl.tudelft.wdm.group1.orders.ResourceNotFoundException;
 import nl.tudelft.wdm.group1.orders.events.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -29,11 +27,11 @@ public class OrderController {
         this.orderRepository = orderRepository;
     }
 
-    @PostMapping
-    public Order addOrder() {
-        Order order = new Order();
+    @PostMapping("/{userId}")
+    public Order addOrder(@PathVariable(value = "userId") UUID userId) {
+        Order order = new Order(userId);
 
-        producer.send(order);
+        producer.emitOrderCreated(order);
 
         return order;
     }
@@ -41,5 +39,43 @@ public class OrderController {
     @GetMapping("/{id}")
     public Order getOrder(@PathVariable(value = "id") UUID id) throws ResourceNotFoundException {
         return orderRepository.find(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public Order deleteOrder(@PathVariable(value = "id") UUID id) throws ResourceNotFoundException {
+        Order order = orderRepository.find(id);
+
+        producer.emitOrderDeleted(order);
+
+        return order;
+    }
+
+    @PostMapping("/{id}/items/{itemId}")
+    public Order addOrderItem(@PathVariable(value = "id") UUID id, @PathVariable(value = "itemId") UUID itemId) throws ResourceNotFoundException {
+        Order order = orderRepository.find(id);
+        order.addItem(itemId);
+
+        producer.emitOrderItemAdded(order);
+
+        return order;
+    }
+
+    @DeleteMapping("/{id}/items/{itemId}")
+    public Order deleteOrderItem(@PathVariable(value = "id") UUID id, @PathVariable(value = "itemId") UUID itemId) throws ResourceNotFoundException {
+        Order order = orderRepository.find(id);
+        order.deleteItem(itemId);
+
+        producer.emitOrderItemDeleted(order);
+
+        return order;
+    }
+
+    @PostMapping("/{id}/checkout")
+    public Order checkoutOrder(@PathVariable(value = "id") UUID id) throws ResourceNotFoundException {
+        Order order = orderRepository.find(id);
+
+        producer.emitOrderCheckedOut(order);
+
+        return order;
     }
 }

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/OrderController.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/OrderController.java
@@ -5,12 +5,7 @@ import nl.tudelft.wdm.group1.orders.OrderRepository;
 import nl.tudelft.wdm.group1.orders.ResourceNotFoundException;
 import nl.tudelft.wdm.group1.orders.events.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -50,8 +45,8 @@ public class OrderController {
         return order;
     }
 
-    @PostMapping("/{id}/items/{itemId}")
-    public Order addOrderItem(@PathVariable(value = "id") UUID id, @PathVariable(value = "itemId") UUID itemId) throws ResourceNotFoundException {
+    @PostMapping("/{id}/items")
+    public Order addOrderItem(@PathVariable(value = "id") UUID id, @RequestParam("itemId") UUID itemId) throws ResourceNotFoundException {
         Order order = orderRepository.find(id);
         order.addItem(itemId);
 
@@ -60,8 +55,8 @@ public class OrderController {
         return order;
     }
 
-    @DeleteMapping("/{id}/items/{itemId}")
-    public Order deleteOrderItem(@PathVariable(value = "id") UUID id, @PathVariable(value = "itemId") UUID itemId) throws ResourceNotFoundException {
+    @DeleteMapping("/{id}/items")
+    public Order deleteOrderItem(@PathVariable(value = "id") UUID id, @RequestParam("itemId") UUID itemId) throws ResourceNotFoundException {
         Order order = orderRepository.find(id);
         order.deleteItem(itemId);
 

--- a/orders/src/main/resources/application.yml
+++ b/orders/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 spring:
   kafka:
-    topic: orders
     consumer:
       bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
       group-id: group_id

--- a/orders/src/test/java/nl/tudelft/wdm/group1/orders/OrdersApplicationTest.java
+++ b/orders/src/test/java/nl/tudelft/wdm/group1/orders/OrdersApplicationTest.java
@@ -63,7 +63,7 @@ public class OrdersApplicationTest {
                 post("/orders/" + defaultOrder.getUserId())
         ).andExpect(status().isOk()).andReturn();
 
-        Thread.sleep(2000); // TODO: Remove this ugly hack
+        Thread.sleep(5000); // TODO: Remove this ugly hack
 
         Order order = orderRepository.find(UUID.fromString(getJsonValue(result, "$.id")));
 
@@ -97,7 +97,7 @@ public class OrdersApplicationTest {
 
         Thread.sleep(2000); // TODO: Remove this ugly hack
 
-        assertThat(defaultOrder.getItemIds()).containsExactly(defaultOrderItemId, newItemId);
+        assertThat(defaultOrder.getItemIds()).contains(defaultOrderItemId, newItemId);
     }
 
     @Test

--- a/orders/src/test/java/nl/tudelft/wdm/group1/orders/OrdersApplicationTest.java
+++ b/orders/src/test/java/nl/tudelft/wdm/group1/orders/OrdersApplicationTest.java
@@ -20,9 +20,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -92,8 +90,10 @@ public class OrdersApplicationTest {
     @Test
     public void addAnItemToAnOrder() throws Exception {
         UUID newItemId = UUID.randomUUID();
-        this.mockMvc.perform(post("/orders/" + defaultOrder.getId() + "/items/" + newItemId))
-                .andExpect(status().isOk());
+        this.mockMvc.perform(
+                post("/orders/" + defaultOrder.getId() + "/items")
+                        .param("itemId", newItemId.toString())
+        ).andExpect(status().isOk());
 
         Thread.sleep(2000); // TODO: Remove this ugly hack
 
@@ -102,8 +102,10 @@ public class OrdersApplicationTest {
 
     @Test
     public void removeAnItemFromAnOrder() throws Exception {
-        this.mockMvc.perform(delete("/orders/" + defaultOrder.getId() + "/items/" + defaultOrderItemId))
-                .andExpect(status().isOk());
+        this.mockMvc.perform(
+                delete("/orders/" + defaultOrder.getId() + "/items")
+                        .param("itemId", defaultOrderItemId.toString())
+        ).andExpect(status().isOk());
 
         Thread.sleep(2000); // TODO: Remove this ugly hack
 


### PR DESCRIPTION
This PR adds the necessary endpoints and event handling for all routes below `/orders`. In our internal planning docs, we said that the 'user creation' event would also need to be handled in this microservice, but I'm not sure why (I've also placed a comment about this in our GDoc), so I've left it out for now.

Closes #10 