### PR TITLE
K8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
+.env
 
 ### STS ###
 .apt_generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
 language: java
 
+services:
+  - docker
+
+install: skip
+script: skip
+
+jobs:
+  include:
+    - stage: test
+      name: "Test orders service"
+      script: ./ci/build.sh orders
+    - script: ./ci/build.sh payments
+      name: "Test payments service"
+    - script: ./ci/build.sh stock
+      name: "Test stock service"
+    - script: ./ci/build.sh users
+      name: "Test users service"
+    - stage: end-to-end
+      name: "Run end-to-end tests"
+      script: ./ci/test.sh
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ docker-compose up
 Run the following commands to get up and running. Kubernetes is set up to pull latest.
 
 ```bash
+# Install nginx ingress in the cluster
+helm install stable/nginx-ingress --name nginx-ingress
+
 # Start Kafka & Zookeeper
 kubectl apply -f k8s/development
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Web-scale Data Management on Kafka
+
+## Setup
+
+### Docker compose (without build)
+
+To start with docker-compose run the following commands.
+
+```bash
+# Pull the images
+docker-compose pull
+
+# Start the services
+docker-compose up
+```
+
+All services are now available on `http://localhost:8080` in their respective directories.
+
+You can specify a specific version by setting the `IMAGE_VERSION` environment variable to a tag on docker hub. Available tags are `<branchname>`, `<branchname_buildnumber>`, `latest`.
+
+### Docker compose (with build)
+
+To start with docker-compsose with building first run the following commands.
+
+```bash
+# Build the jar files
+./gradlew assemble
+
+# Build the docker images
+docker-compose build
+
+# Start the services
+docker-compose up
+```
+
+### Kubernetes
+
+Run the following commands to get up and running. Kubernetes is set up to pull latest.
+
+```bash
+# Start Kafka & Zookeeper
+kubectl apply -f k8s/development
+
+# Start services
+kubectl apply -f k8s/production
+```
+
+After this the orders, payments, stock and users services are accessible on ports 30001, 30002, 30003 and 30004 respectively (this will change to something more sensible).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can specify a specific version by setting the `IMAGE_VERSION` environment va
 
 ### Docker compose (with build)
 
-To start with docker-compsose with building first run the following commands.
+To start with docker-compose with building first run the following commands.
 
 ```bash
 # Build the jar files

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,6 @@ buildscript {
 
 subprojects {
     apply plugin: "java"
-    apply plugin: "org.springframework.boot"
-    apply plugin: 'io.spring.dependency-management'
 
     group = 'nl.tudelft.wdm.group1'
     version = '0.0.1-SNAPSHOT'
@@ -21,6 +19,12 @@ subprojects {
     repositories {
         mavenCentral()
     }
+}
+
+// end-to-end does not need spring
+configure(subprojects - project(":end-to-end")) {
+    apply plugin: "org.springframework.boot"
+    apply plugin: 'io.spring.dependency-management'
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ev
+
+SUB_PROJECT=$1
+IMAGE_NAME=wdmk/${SUB_PROJECT}:${TRAVIS_BRANCH}_${TRAVIS_BUILD_NUMBER}
+IMAGE_NAME_SHORT=wdmk/${SUB_PROJECT}:${TRAVIS_BRANCH}
+
+# Build and test this sub project
+./gradlew :${SUB_PROJECT}:assemble :${SUB_PROJECT}:check
+
+# Create a docker image for this sub project
+docker build -t ${IMAGE_NAME} -t ${IMAGE_NAME_SHORT} ${SUB_PROJECT}
+
+# Login into docker hub
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+# Push the image to docker hub
+docker push ${IMAGE_NAME}
+
+# For branch builds push the image with the branch name as tag
+if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+  docker push ${IMAGE_NAME_SHORT}
+
+  # For master also push to the latest tag
+  if [[ "$TRAVIS_BRANCH" = "master" ]]; then
+    docker tag ${IMAGE_NAME} ${IMAGE_NAME_LATEST}
+    docker push ${IMAGE_NAME} ${IMAGE_NAME_LATEST}
+  fi
+fi
+
+# If a branch is tagged, also push to that tag in docker hub
+if [[ -n "$TRAVIS_TAG" ]]; then
+  IMAGE_NAME_TAG=wdmk/${SUB_PROJECT}:"$TRAVIS_TAG"
+  docker tag ${IMAGE_NAME} ${IMAGE_NAME_TAG}
+  docker push ${IMAGE_NAME} ${IMAGE_NAME_TAG}
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Docker compose looks in .env for environment variables
+echo IMAGE_VERSION=${TRAVIS_BRANCH}_${TRAVIS_BUILD_NUMBER} > .env
+
+# Pull the images created in build.sh from docker hub
+docker-compose pull
+
+# Start the environment in the background
+docker-compose up -d
+
+# Wait until the gateway is ready, so no 504 or 502 status is returned
+attempt_num=1
+
+until curl -Is http://localhost:8080/users | head -1 | grep -v 50
+do
+ if (( attempt_num == 10 ))
+ then
+     return 1
+ else
+     echo Retrying to connect
+     sleep $(( attempt_num++ ))
+ fi
+done
+
+# Run the end to end tests with gradle
+./gradlew end-to-end-test
+
+# Remove the docker containers
+docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,24 +23,28 @@ services:
     ports:
       - "8080:80"
   orders:
+    image: wdmk/orders:${IMAGE_VERSION:-latest}
     build: orders
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   payments:
+    image: wdmk/payments:${IMAGE_VERSION:-latest}
     build: payments
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   stock:
+    image: wdmk/stock:${IMAGE_VERSION:-latest}
     build: stock
     links:
       - kafka
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   users:
+    image: wdmk/users:${IMAGE_VERSION:-latest}
     build: users
     links:
       - kafka

--- a/end-to-end/build.gradle
+++ b/end-to-end/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+    compile group: 'junit', name: 'junit', version: '4.12'
+    compile group: 'io.rest-assured', name: 'rest-assured', version: '4.0.0'
+}
+
+// By default tests and build are disable so they are not ran when the project builds.
+assemble.enabled = false;
+test.enabled = false;
+
+task 'end-to-end-test' {
+    test.enabled = true;
+    dependsOn 'test'
+}

--- a/end-to-end/build.gradle
+++ b/end-to-end/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile group: 'io.rest-assured', name: 'rest-assured', version: '4.0.0'
 }
 
-// By default tests and build are disable so they are not ran when the project builds.
+// By default tests and build are disabled so they are not run when the project builds.
 assemble.enabled = false;
 test.enabled = false;
 

--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endToEnd/EndToEndTest.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endToEnd/EndToEndTest.java
@@ -1,0 +1,24 @@
+package nl.tudelft.wdm.group1.endToEnd;
+
+import static org.hamcrest.Matchers.*;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+
+public class EndToEndTest {
+    @Test
+    public void createAndDeleteUser() {
+        RestAssured
+                .given()
+                .param("firstName", "Jane")
+                .param("lastName", "Da")
+                .param("street", "Main Street")
+                .param("zip", "90101")
+                .param("city", "Rome")
+                .when()
+                .post("http://localhost:8080/users")
+                .then()
+                .body("firstName", equalTo("Jane"))
+                .body("lastName", equalTo("Da"));
+    }
+}

--- a/k8s/development/kafka.yml
+++ b/k8s/development/kafka.yml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wdm-kafka-kafka
+  labels:
+    app: wdm-kafka
+    service: kafka
+spec:
+  containers:
+    - name: kafka
+      image: wurstmeister/kafka
+      ports:
+        - containerPort: 9092
+      env:
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://wdm-kafka-kafka:9092
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://0.0.0.0:9092
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: wdm-kafka-zookeeper:2181
+      livenessProbe:
+        tcpSocket:
+          port: 9092
+        initialDelaySeconds: 60
+        periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-kafka
+  labels:
+    app: wdm-kafka
+    service: kafka
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9092
+      targetPort: 9092
+  selector:
+    app: wdm-kafka
+    service: kafka

--- a/k8s/development/zookeeper.yml
+++ b/k8s/development/zookeeper.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wdm-kafka-zookeeper
+  labels:
+    app: wdm-kafka
+    service: zookeeper
+spec:
+  containers:
+    - name: zookeeper
+      image: wurstmeister/zookeeper
+      ports:
+        - containerPort: 2181
+      livenessProbe:
+        tcpSocket:
+          port: 2181
+        initialDelaySeconds: 60
+        periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-zookeeper
+  labels:
+    app: wdm-kafka
+    service: zookeeper
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2181
+      targetPort: 2181
+  selector:
+    app: wdm-kafka
+    service: zookeeper

--- a/k8s/production/ingress.yml
+++ b/k8s/production/ingress.yml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: wdm-kafka-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - path: /orders
+            backend:
+              serviceName: wdm-kafka-orders
+              servicePort: 8080
+          - path: /payments
+            backend:
+              serviceName: wdm-kafka-payments
+              servicePort: 8080
+          - path: /stock
+            backend:
+              serviceName: wdm-kafka-stock
+              servicePort: 8080
+          - path: /users
+            backend:
+              serviceName: wdm-kafka-users
+              servicePort: 8080

--- a/k8s/production/orders.yml
+++ b/k8s/production/orders.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wdm-kafka-orders
+  labels:
+    app: wdm-kafka
+    service: orders
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wdm-kafka
+      service: orders
+  template:
+    metadata:
+      labels:
+        app: wdm-kafka
+        service: orders
+    spec:
+      containers:
+        - name: orders
+          image: wdmk/orders:k8s # TODO: Make latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: wdm-kafka-kafka:9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-orders
+  labels:
+    app: wdm-kafka
+    service: orders
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30001
+  selector:
+    app: wdm-kafka
+    service: orders

--- a/k8s/production/payments.yml
+++ b/k8s/production/payments.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wdm-kafka-payments
+  labels:
+    app: wdm-kafka
+    service: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wdm-kafka
+      service: payments
+  template:
+    metadata:
+      labels:
+        app: wdm-kafka
+        service: payments
+    spec:
+      containers:
+        - name: payments
+          image: wdmk/payments:k8s # TODO: Make latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: wdm-kafka-kafka:9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-payments
+  labels:
+    app: wdm-kafka
+    service: payments
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30002
+  selector:
+    app: wdm-kafka
+    service: payments

--- a/k8s/production/stock.yml
+++ b/k8s/production/stock.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wdm-kafka-stock
+  labels:
+    app: wdm-kafka
+    service: stock
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wdm-kafka
+      service: stock
+  template:
+    metadata:
+      labels:
+        app: wdm-kafka
+        service: stock
+    spec:
+      containers:
+        - name: stock
+          image: wdmk/stock:k8s # TODO: Make latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: wdm-kafka-kafka:9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-stock
+  labels:
+    app: wdm-kafka
+    service: stock
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30003
+  selector:
+    app: wdm-kafka
+    service: stock

--- a/k8s/production/users.yml
+++ b/k8s/production/users.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wdm-kafka-users
+  labels:
+    app: wdm-kafka
+    service: users
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wdm-kafka
+      service: users
+  template:
+    metadata:
+      labels:
+        app: wdm-kafka
+        service: users
+    spec:
+      containers:
+        - name: users
+          image: wdmk/users:k8s # TODO: Make latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: wdm-kafka-kafka:9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-users
+  labels:
+    app: wdm-kafka
+    service: users
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30004
+  selector:
+    app: wdm-kafka
+    service: users

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ pluginManagement {
 
 rootProject.name = 'wdm-kafka-microservices'
 
-include 'users', 'orders', 'stock', 'payments'
+include 'users', 'orders', 'stock', 'payments', 'end-to-end'


### PR DESCRIPTION
Depends on #9. The images which are pulled can be updated afther that PR is merged. Right now it pulls images from this branch.

See the readme on how to get up and running.

It is split up in two packages, development and production. The development part is Kafka + Zookeeper, because in a real environment these exist. But it probably won't run without Kafka at this specific hostname.

Still needs a load balancer. Probably need to move everything to Helm for more customizability.

Fixes #13.