### PR TITLE
Implement health check for end-to-end & k8s

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -11,19 +11,32 @@ docker-compose pull
 # Start the environment in the background
 docker-compose up -d
 
-# Wait until the gateway is ready, so no 504 or 502 status is returned
-attempt_num=1
+function await {
+    port=$1
+    attempt_num=1
 
-until curl -Is http://localhost:8080/users | head -1 | grep -v 50
-do
- if (( attempt_num == 10 ))
- then
-     return 1
- else
-     echo Retrying to connect
-     sleep $(( attempt_num++ ))
- fi
-done
+    # Wait until status 200 is returned
+    until curl -Is http://localhost:${port} | head -1 | grep 200 > /dev/null
+    do
+     if (( attempt_num == 10 ))
+     then
+         return 1
+     else
+         echo Trying to connect to localhost:${port}
+         sleep $(( attempt_num++ ))
+     fi
+    done
+}
+
+# Check if al services are up
+await 10001
+echo Orders service is up
+await 10002
+echo Payments service is up
+await 10003
+echo Stock service is up
+await 10004
+echo Users service is up
 
 # Run the end to end tests with gradle
 ./gradlew end-to-end-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build: orders
     links:
       - kafka
+    ports:
+      - "10001:8080"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   payments:
@@ -34,6 +36,8 @@ services:
     build: payments
     links:
       - kafka
+    ports:
+      - "10002:8080"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   stock:
@@ -41,6 +45,8 @@ services:
     build: stock
     links:
       - kafka
+    ports:
+      - "10003:8080"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   users:
@@ -48,5 +54,7 @@ services:
     build: users
     links:
       - kafka
+    ports:
+      - "10004:8080"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092

--- a/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/IndexController.java
+++ b/orders/src/main/java/nl/tudelft/wdm/group1/orders/web/IndexController.java
@@ -1,0 +1,18 @@
+package nl.tudelft.wdm.group1.orders.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping(value = "/")
+public class IndexController {
+    /**
+     * Used for health check
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity index() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/payments/src/main/java/nl/tudelft/wdm/group1/payments/web/IndexController.java
+++ b/payments/src/main/java/nl/tudelft/wdm/group1/payments/web/IndexController.java
@@ -1,0 +1,18 @@
+package nl.tudelft.wdm.group1.payments.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping(value = "/")
+public class IndexController {
+    /**
+     * Used for health check
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity index() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/stock/src/main/java/nl/tudelft/wdm/group1/stock/web/IndexController.java
+++ b/stock/src/main/java/nl/tudelft/wdm/group1/stock/web/IndexController.java
@@ -1,0 +1,18 @@
+package nl.tudelft.wdm.group1.stock.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping(value = "/")
+public class IndexController {
+    /**
+     * Used for health check
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity index() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/users/src/main/java/nl/tudelft/wdm/group1/users/web/IndexController.java
+++ b/users/src/main/java/nl/tudelft/wdm/group1/users/web/IndexController.java
@@ -1,0 +1,18 @@
+package nl.tudelft.wdm.group1.users.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping(value = "/")
+public class IndexController {
+    /**
+     * Used for health check
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity index() {
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
K8s healthcheck is based on pinging `/` on a service and expecting it to return a `200` status code.

Using this in the end to end test script also makes it a bit more elegant.

Seperate services are now also available on 10001, 10002, 10003, 10004 for the orders, payments, stock and users services.