### PR TITLE
Split up build process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,22 @@ jobs:
   include:
     - stage: test
       name: "Test orders service"
+      script: ./gradlew :orders:check
+    - name: "Test payments service"
+      script: ./gradlew :payments:check
+    - name: "Test stock service"
+      script: ./gradlew :stock:check
+    - name: "Test users service"
+      script: ./gradlew :users:check
+    - stage: build
+      name: "Build orders service"
       script: ./ci/build.sh orders
-    - script: ./ci/build.sh payments
-      name: "Test payments service"
-    - script: ./ci/build.sh stock
-      name: "Test stock service"
-    - script: ./ci/build.sh users
-      name: "Test users service"
+    - name: "Build payments service"
+      script: ./ci/build.sh payments
+    - name: "Build stock service"
+      script: ./ci/build.sh stock
+    - name: "Build users service"
+      script: ./ci/build.sh users
     - stage: end-to-end
       name: "Run end-to-end tests"
       script: ./ci/test.sh

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -28,6 +28,8 @@ function await {
     done
 }
 
+./gradlew :end-to-end:testClasses
+
 # Check if al services are up
 await 10001
 echo Orders service is up


### PR DESCRIPTION
Split testing and pushing to Docker Hub. This makes sure that images
are not pushed to Docker Hub if there is a test error.