### PR TITLE
Fix ingress for gke

### DIFF
--- a/k8s/production/ingress.yml
+++ b/k8s/production/ingress.yml
@@ -13,7 +13,15 @@ spec:
             backend:
               serviceName: wdm-kafka-orders
               servicePort: 8080
+          - path: /orders/*
+            backend:
+              serviceName: wdm-kafka-orders
+              servicePort: 8080
           - path: /payments
+            backend:
+              serviceName: wdm-kafka-payments
+              servicePort: 8080
+          - path: /payments/*
             backend:
               serviceName: wdm-kafka-payments
               servicePort: 8080
@@ -21,7 +29,15 @@ spec:
             backend:
               serviceName: wdm-kafka-stock
               servicePort: 8080
+          - path: /stock/*
+            backend:
+              serviceName: wdm-kafka-stock
+              servicePort: 8080
           - path: /users
+            backend:
+              serviceName: wdm-kafka-users
+              servicePort: 8080
+          - path: /users/*
             backend:
               serviceName: wdm-kafka-users
               servicePort: 8080


### PR DESCRIPTION
The GKE ingress controller is not that smart. `/subdir` matches just
that directory and `/subdir/*` matches everything in that subdir, but
not the directory itself. So they are both added to the definition.