### PR TITLE
Make dockerfiles not depend on location of java

### DIFF
--- a/orders/Dockerfile
+++ b/orders/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:8-jre-slim
 COPY build/libs/orders-0.0.1-SNAPSHOT.jar .
-CMD /usr/bin/java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar orders-0.0.1-SNAPSHOT.jar
+CMD java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar orders-0.0.1-SNAPSHOT.jar
 EXPOSE 8080

--- a/payments/Dockerfile
+++ b/payments/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:8-jre-slim
 COPY build/libs/payments-0.0.1-SNAPSHOT.jar .
-CMD /usr/bin/java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar payments-0.0.1-SNAPSHOT.jar
+CMD java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar payments-0.0.1-SNAPSHOT.jar
 EXPOSE 8080

--- a/stock/Dockerfile
+++ b/stock/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:8-jre-slim
 COPY build/libs/stock-0.0.1-SNAPSHOT.jar .
-CMD /usr/bin/java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar stock-0.0.1-SNAPSHOT.jar
+CMD java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar stock-0.0.1-SNAPSHOT.jar
 EXPOSE 8080

--- a/users/Dockerfile
+++ b/users/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:8-jre-slim
 COPY build/libs/users-0.0.1-SNAPSHOT.jar .
-CMD /usr/bin/java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar users-0.0.1-SNAPSHOT.jar
+CMD java -Xmx400m -Xms400m  -XX:TieredStopAtLevel=1 -noverify -jar users-0.0.1-SNAPSHOT.jar
 EXPOSE 8080


### PR DESCRIPTION
So they changed how the `openjdk:8-jre-slim` image works and the java executable is now in `/usr/local/openjdk-8/bin` instead of `/usr/local/bin`. So I changed it to just `java` which works as wel..