### PR TITLE
Add Locust load testing

### DIFF
--- a/locust/README.md
+++ b/locust/README.md
@@ -1,0 +1,17 @@
+# Web-scale Data Management on Kafka - Locust Load Testing
+
+Requirements:
+* Python 3
+
+## Usage Instructions
+Install locust using 
+```
+pip install locust
+```
+
+Run
+```
+locust --host=http://localhost:8080/
+```
+
+Go to `http://localhost:8089/` and start the load test.

--- a/locust/README.md
+++ b/locust/README.md
@@ -11,7 +11,7 @@ pip install locust
 
 Run
 ```
-locust --host=http://localhost:8080/
+locust --host=http://localhost:8080
 ```
 
 Go to `http://localhost:8089/` and start the load test.

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -1,0 +1,54 @@
+import random
+
+import requests
+from locust import HttpLocust, seq_task, TaskSequence, task
+
+stock_items = []
+
+
+def create_stock_items(l):
+    for i in range(1, 20):
+        response = requests.post(l.host + "/stock", {
+            "stock": 15000000,
+            "name": "TurboKafka2000",
+            "price": 1240
+        })
+        stock_items.append(response.json()['id'])
+
+
+class MyTaskSequence(TaskSequence):
+    @seq_task(1)
+    def create_user(self):
+        response = self.client.post("/users", {
+            "firstName": "Casper",
+            "lastName": "Boone",
+            "street": "Mekelpark",
+            "zip": "2142AB",
+            "city": "Delft"
+        })
+        self.user_id = response.json()['id']
+
+    @seq_task(2)
+    def create_order(self):
+        response = self.client.post("/orders/" + self.user_id)
+        self.order_id = response.json()['id']
+
+    @seq_task(3)
+    @task(4)  # add four items
+    def add_order_item(self):
+        self.client.post("/orders/" + self.order_id + "/items", {
+            "itemId": random.choice(stock_items)
+        })
+
+    @seq_task(4)
+    def checkout_order(self):
+        self.client.post("/orders/" + self.order_id + "/checkout")
+
+
+class WebsiteUser(HttpLocust):
+    task_set = MyTaskSequence
+    min_wait = 5000
+    max_wait = 9000
+
+    def setup(self):
+        create_stock_items(self)

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -16,13 +16,13 @@ def create_stock_items(l):
         stock_items.append(response.json()['id'])
 
 
-class MyTaskSequence(TaskSequence):
+class OrderTaskSequence(TaskSequence):
     @seq_task(1)
     def create_user(self):
         response = self.client.post("/users", {
-            "firstName": "Casper",
-            "lastName": "Boone",
-            "street": "Mekelpark",
+            "firstName": "Tom",
+            "lastName": "de Vries",
+            "street": "Mekelpark 12",
             "zip": "2142AB",
             "city": "Delft"
         })
@@ -45,8 +45,8 @@ class MyTaskSequence(TaskSequence):
         self.client.post("/orders/" + self.order_id + "/checkout")
 
 
-class WebsiteUser(HttpLocust):
-    task_set = MyTaskSequence
+class User(HttpLocust):
+    task_set = OrderTaskSequence
     min_wait = 5000
     max_wait = 9000
 


### PR DESCRIPTION
This PR adds load testing using Locust.

## Requirements
Requirements:
* Python 3

## Usage Instructions
Install locust using 
```
pip install locust
```

Run
```
locust --host=http://localhost:8080/
```

Go to `http://localhost:8089/` and start the load test.

## What is missing
At the moment we don't add credit for the user. We should add this, however, since the order checkout does not fail on not doing this yet I have left it out for now.

After a while I get `'ConnectionError(MaxRetryError("HTTPConnectionPool(host=\'localhost\', port=8080): Max retries exceeded with url: //users (Caused by NewConnectionError(\'<urllib3.connection.HTTPConnection object at 0x1108d4c18>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known\'))"))`. I have not yet figured if this is because of the application or because of my set up. The docs mention increasing the [max number of open files limit](https://docs.locust.io/en/latest/installation.html#increasing-maximum-number-of-open-files-limit), maybe this is the issue.