### PR TITLE
Update k8s for rest

### DIFF
--- a/k8s/production/ingress.yml
+++ b/k8s/production/ingress.yml
@@ -9,35 +9,6 @@ spec:
   rules:
     - http:
         paths:
-          - path: /orders
-            backend:
-              serviceName: wdm-kafka-orders
-              servicePort: 8080
-          - path: /orders/*
-            backend:
-              serviceName: wdm-kafka-orders
-              servicePort: 8080
-          - path: /payments
-            backend:
-              serviceName: wdm-kafka-payments
-              servicePort: 8080
-          - path: /payments/*
-            backend:
-              serviceName: wdm-kafka-payments
-              servicePort: 8080
-          - path: /stock
-            backend:
-              serviceName: wdm-kafka-stock
-              servicePort: 8080
-          - path: /stock/*
-            backend:
-              serviceName: wdm-kafka-stock
-              servicePort: 8080
-          - path: /users
-            backend:
-              serviceName: wdm-kafka-users
-              servicePort: 8080
-          - path: /users/*
-            backend:
-              serviceName: wdm-kafka-users
+          - backend:
+              serviceName: wdm-kafka-rest
               servicePort: 8080

--- a/k8s/production/rest.yml
+++ b/k8s/production/rest.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wdm-kafka-rest
+  labels:
+    app: wdm-kafka
+    service: rest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wdm-kafka
+      service: rest
+  template:
+    metadata:
+      labels:
+        app: wdm-kafka
+        service: rest
+    spec:
+      containers:
+        - name: rest
+          image: wdmk/rest:latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: wdm-kafka-kafka:9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wdm-kafka-rest
+  labels:
+    app: wdm-kafka
+    service: rest
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30000
+  selector:
+    app: wdm-kafka
+    service: rest


### PR DESCRIPTION
Add k8s manifest for rest and update ingress to point only to the rest server. The rest service is also accessible on NodePort `30000`.

Fixes #55