### PR TITLE
Make order checkout stateful

### DIFF
--- a/common/src/main/java/nl/tudelft/wdm/group1/common/QueueMap.java
+++ b/common/src/main/java/nl/tudelft/wdm/group1/common/QueueMap.java
@@ -1,0 +1,29 @@
+package nl.tudelft.wdm.group1.common;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+
+public class QueueMap<K, V> {
+    private Map<K, Queue<V>> internal;
+
+    public QueueMap() {
+        internal = new HashMap<>();
+    }
+
+    public V poll(K key) {
+        return internal.get(key).poll();
+    }
+
+    public V put(K key, V value) {
+        if (internal.containsKey(key)) {
+            internal.get(key).add(value);
+        } else {
+            Queue<V> queue = new LinkedList<>();
+            queue.add(value);
+            internal.put(key, queue);
+        }
+        return value;
+    }
+}

--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndBase.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndBase.java
@@ -66,6 +66,12 @@ public abstract class EndToEndBase {
                 .then().statusCode(200);
     }
 
+    protected void checkoutOrderFailure(UUID order, int status) {
+        given()
+                .when().post("/orders/" + order + "/checkout")
+                .then().statusCode(status);
+    }
+
     protected void deleteOrderItem(UUID order, UUID itemId) {
         given().param("itemId", itemId)
                 .when().delete("/orders/" + order + "/items")

--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndTest.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndTest.java
@@ -89,7 +89,6 @@ public class EndToEndTest extends EndToEndBase {
 
         // make the transaction
         checkoutOrder(order);
-        await().until(() -> !getOrderStatus(order).equals("PROCESSING"));
         String status = getOrderStatus(order);
 
         // check values in the system
@@ -147,8 +146,7 @@ public class EndToEndTest extends EndToEndBase {
         Assert.assertEquals(1, itemIds1.size());
 
         // make the transaction
-        checkoutOrder(order1);
-        await().until(() -> !getOrderStatus(order1).equals("PROCESSING"));
+        checkoutOrderFailure(order1, 404);
         String status1 = getOrderStatus(order1);
 
         // check that the item is sold out
@@ -191,8 +189,7 @@ public class EndToEndTest extends EndToEndBase {
         Assert.assertEquals(3, itemIds0.size());
 
         // make the transaction
-        checkoutOrder(order0);
-        await().until(() -> !(getOrderStatus(order0).equals("PROCESSING")));
+        checkoutOrderFailure(order0, 422);
         String status0 = getOrderStatus(order0);
 
         // check that the order is rejected due to lack of credit

--- a/service/orders/src/test/java/nl/tudelft/wdm/group1/orders/events/ConsumerTest.java
+++ b/service/orders/src/test/java/nl/tudelft/wdm/group1/orders/events/ConsumerTest.java
@@ -22,7 +22,8 @@ public class ConsumerTest {
     public void setUp() {
         producer = mock(Producer.class);
         orderRepository = mock(OrderRepository.class);
-        consumer = new Consumer(orderRepository, producer);
+        Rest rest = mock(Rest.class);
+        consumer = new Consumer(orderRepository, producer, rest);
     }
 
     @Test


### PR DESCRIPTION
When multiple checkout requests for the same order are received they are responded to in the order they were received. This might impose timing issues under very heavy load. Another option is to reject any checkout requests if one is already in progress, this would still require some kind of timeout mechanism such that any errors in the processing pipeline will not cause an order to be stuck.