### PR TITLE
Use event for StockItemCreate->DB handling

### DIFF
--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndBase.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndBase.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.awaitility.Awaitility;
 import org.junit.Before;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
@@ -171,7 +172,7 @@ public abstract class EndToEndBase {
         return userIds;
     }
 
-    protected List<UUID> createStocks() {
+    protected List<UUID> createStocks() throws InterruptedException {
         List<Map<String, String>> stocks = new ArrayList<Map<String, String>>() {{
             add(new HashMap<String, String>() {{
                 put("stock", "30");
@@ -200,6 +201,8 @@ public abstract class EndToEndBase {
             stockResponse.then().statusCode(200);
 
             UUID id = UUID.fromString(stockResponse.jsonPath().get("id"));
+
+            Thread.sleep(5000);
 
             await().untilAsserted(() -> given().when().get("/stock/" + id).then().statusCode(200));
 

--- a/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndTest.java
+++ b/end-to-end/src/test/java/nl/tudelft/wdm/group1/endtoend/EndToEndTest.java
@@ -1,14 +1,18 @@
 package nl.tudelft.wdm.group1.endtoend;
-import java.util.*;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import static org.awaitility.Awaitility.await;
 
 public class EndToEndTest extends EndToEndBase {
 
     @Test
-    public void createAndDeleteUser() {
+    public void createAndDeleteUser() throws InterruptedException {
         List<UUID> users = createUsers();
         List<UUID> stocks = createStocks();
 

--- a/service/stock/src/main/java/nl/tudelft/wdm/group1/stock/events/Rest.java
+++ b/service/stock/src/main/java/nl/tudelft/wdm/group1/stock/events/Rest.java
@@ -1,7 +1,12 @@
 package nl.tudelft.wdm.group1.stock.events;
 
 import nl.tudelft.wdm.group1.common.*;
+import nl.tudelft.wdm.group1.common.exception.InsufficientStockException;
+import nl.tudelft.wdm.group1.common.exception.InvalidStockChangeException;
+import nl.tudelft.wdm.group1.common.exception.ResourceNotFoundException;
+import nl.tudelft.wdm.group1.common.model.StockItem;
 import nl.tudelft.wdm.group1.common.payload.*;
+import nl.tudelft.wdm.group1.common.topic.RestTopics;
 import nl.tudelft.wdm.group1.stock.StockItemRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaHandler;

--- a/service/stock/src/main/java/nl/tudelft/wdm/group1/stock/events/Rest.java
+++ b/service/stock/src/main/java/nl/tudelft/wdm/group1/stock/events/Rest.java
@@ -1,16 +1,7 @@
 package nl.tudelft.wdm.group1.stock.events;
 
-import nl.tudelft.wdm.group1.common.KafkaErrorResponse;
-import nl.tudelft.wdm.group1.common.KafkaResponse;
-import nl.tudelft.wdm.group1.common.exception.InsufficientStockException;
-import nl.tudelft.wdm.group1.common.exception.InvalidStockChangeException;
-import nl.tudelft.wdm.group1.common.exception.ResourceNotFoundException;
-import nl.tudelft.wdm.group1.common.model.StockItem;
-import nl.tudelft.wdm.group1.common.payload.StockItemAddAmountPayload;
-import nl.tudelft.wdm.group1.common.payload.StockItemCreatePayload;
-import nl.tudelft.wdm.group1.common.payload.StockItemGetPayload;
-import nl.tudelft.wdm.group1.common.payload.StockItemSubtractAmountPayload;
-import nl.tudelft.wdm.group1.common.topic.RestTopics;
+import nl.tudelft.wdm.group1.common.*;
+import nl.tudelft.wdm.group1.common.payload.*;
 import nl.tudelft.wdm.group1.stock.StockItemRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -37,7 +28,7 @@ public class Rest {
     @KafkaHandler
     public void consumeStockItemCreate(StockItemCreatePayload payload) {
         StockItem stockItem = new StockItem(payload.getStock(), payload.getName(), payload.getPrice());
-        stockItemRepository.save(stockItem);
+        producer.emitStockItemAdded(stockItem);
         rest.sendDefault(new KafkaResponse<>(payload.getRequestId(), stockItem));
     }
 


### PR DESCRIPTION
Currently, the `emitStockItemAdded` method is unused, since the consumer of stockItemCreate in the Rest controller did not use it and simply persisted directly. This will cause issues when partitioning, so I'm using the emitter, now.